### PR TITLE
Correct error message for student login to email/password should be a string

### DIFF
--- a/src/ignitus-StudentLogin/actions.js
+++ b/src/ignitus-StudentLogin/actions.js
@@ -7,9 +7,9 @@ import _ from 'lodash';
 
 export const logInRequest = (email, password) => {
   if (!_.isString(email))
-    throw new Error(`email must be number: ` + email);
+    throw new Error(`email must be a string: ` + email);
   if (!_.isString(password))
-    throw new Error(`password must be number: ` + password);
+    throw new Error(`password must be a string: ` + password);
 
   return {type: t.LOG_IN_REQUEST, email, password};
 };


### PR DESCRIPTION
## Description
The error being thrown incorrectly stated the email and password should be numbers. It should ask for strings.

## Motivation and Context
Stumbled on it while looking through the code.

## How Has This Been Tested?
Added a logging statement and saw the error message being logged to the console.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
