### PR TITLE
ESLint configuration updates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,23 +6,45 @@
   },
   "parserOptions": {
     "ecmaFeatures": {
-        "jsx": true,
-        "modules": true
+      "jsx": true,
+      "modules": true
     }
-},
-"settings": {
-  "import/resolver": {
-    "node": {
-      "extensions": [".js", ".jsx", ".ts", ".tsx"]
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx"
+        ]
+      }
     }
   },
   "rules": {
+    "import/prefer-default-export": "off",
+    "import/no-default-export": "warn",
+    "import/extensions": [
+      "warn",
+      "always",
+      {
+        "js": "never",
+        "jsx": "never",
+        "ts": "never",
+        "tsx": "never"
+      }
+    ],
     "react/jsx-filename-extension": [
       1,
       {
-        "extensions": [".js", ".jsx",".ts", ".tsx"]
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx"
+        ]
       }
     ]
   }
-}
 }


### PR DESCRIPTION
As of #761, ```import/no-default-export``` warnings would be useful to detect ```export default```.

When complete migration is done, we will replace ```warn``` to ```error``` to enforce not to use ```export default```.

```import/extensions``` will reduce these errors.

![Screenshot from 2020-04-11 21-57-39](https://user-images.githubusercontent.com/17699717/79049250-1c229100-7c40-11ea-9c6e-4afaa5909f93.png)
 