### PR TITLE
[ignitus-Shared]: Add Avatar component

### DIFF
--- a/src/ignitus-Routes/ignitus-UserInterfaceBookRoutes/index.tsx
+++ b/src/ignitus-Routes/ignitus-UserInterfaceBookRoutes/index.tsx
@@ -25,6 +25,7 @@ import {interfaceMultiMediaInput} from '../../ignitus-UserInterfaceBook/Componen
 import {interfaceOverlay} from '../../ignitus-UserInterfaceBook/Components/Molecules/interfaceOverlay/Components';
 import {interfaceFilters} from '../../ignitus-UserInterfaceBook/Components/Templates/interfaceFilters/Components/index';
 import {interfaceUserProfile} from '../../ignitus-UserInterfaceBook/Components/Organisms/interfaceUserProfile/Components';
+import {InterfaceAvatar} from '../../ignitus-UserInterfaceBook/Components/Organisms/interfaceAvatar/Components';
 
 const Container = styled.div`
   display: flex;
@@ -115,6 +116,7 @@ const UserInterfaceBookRoutes: React.FunctionComponent = () => (
         <Route path="/interface/filters" component={interfaceFilters} />
         <Route path="/interface/userProfile" component={interfaceUserProfile} />
         <Route path="/interface/overlay" component={interfaceOverlay} />
+        <Route path="/interface/avatar" component={InterfaceAvatar} />
       </Switch>
     </LeftRow>
   </Container>

--- a/src/ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar/Components/Avatar.tsx
+++ b/src/ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar/Components/Avatar.tsx
@@ -1,0 +1,14 @@
+import React, {HTMLAttributes} from 'react';
+import {avatars} from '../avatars';
+import {AvatarImage} from '../styles';
+import {avatar} from '../types';
+
+const randomAvatar = () => (avatars[Math.floor(Math.random() * avatars.length)]);
+
+export const Avatar: React.FC<HTMLAttributes<HTMLImageElement>> = ({
+  ...all
+}) => {
+  const av: avatar = randomAvatar();
+
+  return <AvatarImage src={av.src} alt={av.name} {...all} />
+};

--- a/src/ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar/avatars.ts
+++ b/src/ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar/avatars.ts
@@ -1,0 +1,15 @@
+import { avatar } from './types';
+
+const pre = 'https://storage.googleapis.com/ignitus_assets/ig-avatars/';
+
+const avatarNames = [
+  'grant',
+  'melanie',
+  'george',
+  'eugene'
+];
+
+export const avatars: avatar[] = avatarNames.map((avatar) => ({
+  name: avatar,
+  src: `${pre}${avatar}.png`,
+}));

--- a/src/ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar/index.ts
+++ b/src/ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar/index.ts
@@ -1,0 +1,1 @@
+export { Avatar } from './Components/Avatar';

--- a/src/ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar/styles.ts
+++ b/src/ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar/styles.ts
@@ -1,0 +1,5 @@
+import styled from '@emotion/styled';
+
+export const AvatarImage = styled.img`
+  max-width: 9rem;
+`;

--- a/src/ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar/types.ts
+++ b/src/ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar/types.ts
@@ -1,0 +1,4 @@
+export type avatar = {
+  name: string;
+  src: string;
+};

--- a/src/ignitus-UserInterfaceBook/Components/Organisms/interfaceAvatar/Components/index.tsx
+++ b/src/ignitus-UserInterfaceBook/Components/Organisms/interfaceAvatar/Components/index.tsx
@@ -1,0 +1,25 @@
+import React, {useState} from 'react';
+
+import {Heading2} from '../../../../../ignitus-Shared/ignitus-DesignSystem/ignitus-Atoms/typography';
+import {Interface} from '../../../../styles';
+import {Avatar} from '../../../../../ignitus-Shared/ignitus-DesignSystem/ignitus-Organisms/ignitus-Avatar';
+import {Button} from '../../../../../ignitus-Shared/ignitus-DesignSystem/ignitus-Atoms/buttons';
+
+export const InterfaceAvatar: React.FC = () => {
+  const [,update] = useState();
+  const forceUpdate = () => update({});
+
+  return (
+    <Interface>
+      <Heading2>
+        Random Avatar
+    </Heading2>
+      <hr />
+      <Avatar />
+      <br />
+      <Button category="primary" size="small" onClick={forceUpdate}>
+        Generate Random
+      </Button>
+    </Interface>
+  );
+}

--- a/src/ignitus-UserInterfaceBook/InterfaceSideNavigation/constants.ts
+++ b/src/ignitus-UserInterfaceBook/InterfaceSideNavigation/constants.ts
@@ -165,6 +165,10 @@ export const edges: Edges[] = [
           },
         ],
       },
+      {
+        title: 'Random Avatar',
+        route: '/interface/avatar',
+      },
     ],
   },
   {


### PR DESCRIPTION
Fixes #796 .

Component provides random avatar image listed in GCP. 
Component can be modified through ```@emotion/styled```.

```avatars``` array is exported, therefore All avatar image can be listed for selection if required.

Compoenent is added in interface book at ```/interface/avatar```