### PR TITLE
allowed indexing of ignitus.org

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,1 @@
 User-agent: *	
-Disallow: /	


### PR DESCRIPTION
allowed indexing of [Ignitus](ignitus.org) by search engines such as `Google crawler`.

Related to issue #865 